### PR TITLE
fix incorrect job_id

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -768,7 +768,7 @@
                             
                             jobsHTML += `
                                 <tr>
-                                    <td>${job.job_id || 'N/A'}</td>
+                                    <td>${job.job_id || '—'}</td>
                                     <td class="hash ${hashClass}" title="${job.prevhash || 'N/A'}">${job.prevhash ? job.prevhash.substring(0, 20) + '...' : 'N/A'}</td>
                                     <td>${time}</td>
                                     <td class="hash-age ${ageClass}">${age}s ago</td>

--- a/src/normalizer.py
+++ b/src/normalizer.py
@@ -21,7 +21,7 @@ def normalize(source_type, data):
             # Observer hash is already in the correct byte order
             return {
                 "source": "observer",
-                "job_id": data.get("coinbase_tag") or data.get("pool_name"),
+                "job_id": None, # Observer doesn't provide actual job IDs. Maybe do away with job_id entirely?
                 "prevhash": data.get("prev_hash"),
                 "timestamp": _safe_ts(data.get("job_timestamp") or data.get("header_time"))
             }


### PR DESCRIPTION
The observer source was incorrectly using coinbase_tag (e.g., "AntPool", "ckpool") as the job ID. The coinbase tag is just a miner identifier included in blocks, not an actual job ID. The solution attempted here is to set job_id to None for the observer source since it doesn't provide actual job IDs. I believe that this would be aligned with 0xB10C's observation that comparing job IDs between different sources isn't meaningful anyway, as they will always be different. 

Fixes #22